### PR TITLE
Expose whether in delegatecall or callcode

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -50,6 +50,9 @@ type Contract struct {
 	caller        ContractRef
 	self          ContractRef
 
+	// Arbitrum
+	delegateOrCallcode bool
+
 	jumpdests map[common.Hash]bitvec // Aggregated result of JUMPDEST analysis.
 	analysis  bitvec                 // Locally cached result of JUMPDEST analysis
 

--- a/core/vm/contract_arbitrum.go
+++ b/core/vm/contract_arbitrum.go
@@ -24,3 +24,7 @@ func (c *Contract) BurnGas(amount uint64) error {
 	c.Gas -= amount
 	return nil
 }
+
+func (c *Contract) IsDelegateOrCallcode() bool {
+	return c.delegateOrCallcode
+}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -315,6 +315,10 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 		// The contract is a scoped environment for this execution context only.
 		contract := NewContract(caller, AccountRef(caller.Address()), value, gas)
 		contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy))
+
+		// Arbitrum: note the callcode
+		contract.delegateOrCallcode = true
+
 		ret, err = evm.interpreter.Run(contract, input, false)
 		gas = contract.Gas
 	}
@@ -368,6 +372,10 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 		// Initialise a new contract and make initialise the delegate values
 		contract := NewContract(caller, AccountRef(caller.Address()), nil, gas).AsDelegate()
 		contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy))
+
+		// Arbitrum: note the delegate call
+		contract.delegateOrCallcode = true
+
 		ret, err = evm.interpreter.Run(contract, input, false)
 		gas = contract.Gas
 	}

--- a/core/vm/evm_arbitrum.go
+++ b/core/vm/evm_arbitrum.go
@@ -40,8 +40,8 @@ func (evm *EVM) DecrementDepth() {
 type TxProcessingHook interface {
 	StartTxHook() (bool, uint64, error, []byte) // return 4-tuple rather than *struct to avoid an import cycle
 	GasChargingHook(gasRemaining *uint64) (common.Address, error)
-	PushContract(contract *Contract, stylus bool)
-	PopContract(stylus bool)
+	PushContract(contract *Contract)
+	PopContract()
 	ForceRefundGas() uint64
 	NonrefundableGas() uint64
 	DropTip() bool
@@ -67,9 +67,9 @@ func (p DefaultTxProcessor) GasChargingHook(gasRemaining *uint64) (common.Addres
 	return p.evm.Context.Coinbase, nil
 }
 
-func (p DefaultTxProcessor) PushContract(contract *Contract, stylus bool) {}
+func (p DefaultTxProcessor) PushContract(contract *Contract) {}
 
-func (p DefaultTxProcessor) PopContract(stylus bool) {}
+func (p DefaultTxProcessor) PopContract() {}
 
 func (p DefaultTxProcessor) ForceRefundGas() uint64 { return 0 }
 


### PR DESCRIPTION
Exposes whether or not the current `Contract` came from `DelegateCall` or `CallCode`.

Additionally, this PR supports a minor optimization to `Push/PopCaller` to make caller-tracking pointer based.