### PR TITLE
Add support for StylusArbOSVersion

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -142,6 +142,10 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 	}
 }
 
+func NewArbosPrecompilesAtVersion(arbosVersion uint64) []common.Address {
+	return ArbosVersionPrecompiledAddresses[arbosVersion]
+}
+
 type AdvancedPrecompileCall struct {
 	PrecompileAddress common.Address
 	ActingAsAddress   common.Address

--- a/core/vm/contracts_arbitrum.go
+++ b/core/vm/contracts_arbitrum.go
@@ -3,6 +3,7 @@ package vm
 import "github.com/ethereum/go-ethereum/common"
 
 var (
-	PrecompiledContractsArbitrum = make(map[common.Address]PrecompiledContract)
-	PrecompiledAddressesArbitrum []common.Address
+	PrecompiledContractsArbitrum     = make(map[common.Address]PrecompiledContract)
+	PrecompiledAddressesArbitrum     []common.Address
+	ArbosVersionPrecompiledAddresses = make(map[uint64][]common.Address)
 )

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -522,7 +522,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		err = ErrInvalidCode
 		// Arbitrum: We do not reject Stylus programs and instead store them in the DB
 		// alongside normal EVM bytecode.
-		if evm.chainRules.IsArbitrum && state.IsStylusProgram(ret) {
+		if evm.chainConfig.ArbitrumStylusEnabled(evm.Context.ArbOSVersion) && state.IsStylusProgram(ret) {
 			err = nil
 		}
 	}

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -29,6 +29,7 @@ type ArbitrumChainParams struct {
 	InitialArbOSVersion       uint64
 	InitialChainOwner         common.Address
 	GenesisBlockNum           uint64
+	StylusArbOSVersion        uint64
 }
 
 func (c *ChainConfig) IsArbitrum() bool {
@@ -39,11 +40,16 @@ func (c *ChainConfig) IsArbitrumNitro(num *big.Int) bool {
 	return c.IsArbitrum() && isBlockForked(new(big.Int).SetUint64(c.ArbitrumChainParams.GenesisBlockNum), num)
 }
 
+func (c *ChainConfig) ArbitrumStylusEnabled(arbOSVersion uint64) bool {
+	stylusArbOSVersion := c.ArbitrumChainParams.StylusArbOSVersion
+	return c.IsArbitrum() && stylusArbOSVersion != 0 && arbOSVersion >= stylusArbOSVersion
+}
+
 func (c *ChainConfig) DebugMode() bool {
 	return c.ArbitrumChainParams.AllowDebugPrecompiles
 }
 
-func (c *ChainConfig) checkArbitrumCompatible(newcfg *ChainConfig, head *big.Int) *ConfigCompatError {
+func (c *ChainConfig) checkArbitrumCompatible(newcfg *ChainConfig, _ *big.Int) *ConfigCompatError {
 	if c.IsArbitrum() != newcfg.IsArbitrum() {
 		// This difference applies to the entire chain, so report that the genesis block is where the difference appears.
 		return newBlockCompatError("isArbitrum", common.Big0, common.Big0)
@@ -55,6 +61,9 @@ func (c *ChainConfig) checkArbitrumCompatible(newcfg *ChainConfig, head *big.Int
 	newArb := &newcfg.ArbitrumChainParams
 	if cArb.GenesisBlockNum != newArb.GenesisBlockNum {
 		return newBlockCompatError("genesisblocknum", new(big.Int).SetUint64(cArb.GenesisBlockNum), new(big.Int).SetUint64(newArb.GenesisBlockNum))
+	}
+	if cArb.StylusArbOSVersion != 0 && cArb.StylusArbOSVersion != newArb.StylusArbOSVersion {
+		return newBlockCompatError("stylusArbOSVersion", nil, nil)
 	}
 	return nil
 }
@@ -106,6 +115,7 @@ func ArbitrumDevTestParams() ArbitrumChainParams {
 		DataAvailabilityCommittee: false,
 		InitialArbOSVersion:       11,
 		InitialChainOwner:         common.Address{},
+		StylusArbOSVersion:        11,
 	}
 }
 


### PR DESCRIPTION
Add chain parameter StylusArbOSVersion to gate enabling Stylus to a specific ArbOS version
Required by:
https://github.com/OffchainLabs/stylus/pull/158