### PR TITLE
Extend hostio tracing

### DIFF
--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -34,7 +34,7 @@ type EVMLogger interface {
 	CaptureArbitrumStorageSet(key, value common.Hash, depth int, before bool)
 
 	// Stylus: capture hostio invocation
-	CaptureStylusHostio(name string, args, outs []byte, ink uint64)
+	CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64)
 
 	// Transaction level
 	CaptureTxStart(gasLimit uint64)

--- a/eth/tracers/js/tracer_arbitrum.go
+++ b/eth/tracers/js/tracer_arbitrum.go
@@ -56,7 +56,7 @@ func (jst *jsTracer) CaptureArbitrumTransfer(
 func (*jsTracer) CaptureArbitrumStorageGet(key common.Hash, depth int, before bool)        {}
 func (*jsTracer) CaptureArbitrumStorageSet(key, value common.Hash, depth int, before bool) {}
 
-func (jst *jsTracer) CaptureStylusHostio(name string, args, outs []byte, ink uint64) {
+func (jst *jsTracer) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64) {
 	hostio, ok := goja.AssertFunction(jst.obj.Get("hostio"))
 	if !ok {
 		return
@@ -66,7 +66,8 @@ func (jst *jsTracer) CaptureStylusHostio(name string, args, outs []byte, ink uin
 	info.Set("name", name)
 	info.Set("args", args)
 	info.Set("outs", outs)
-	info.Set("ink", ink)
+	info.Set("startInk", startInk)
+	info.Set("endInk", endInk)
 
 	if _, err := hostio(jst.obj, info); err != nil {
 		jst.err = wrapError("hostio", err)

--- a/eth/tracers/logger/logger_arbitrum.go
+++ b/eth/tracers/logger/logger_arbitrum.go
@@ -42,7 +42,8 @@ func (*JSONLogger) CaptureArbitrumStorageSet(key, value common.Hash, depth int, 
 func (*StructLogger) CaptureArbitrumStorageSet(key, value common.Hash, depth int, before bool)     {}
 func (*mdLogger) CaptureArbitrumStorageSet(key, value common.Hash, depth int, before bool)         {}
 
-func (*AccessListTracer) CaptureStylusHostio(name string, args, outs []byte, ink uint64) {}
-func (*JSONLogger) CaptureStylusHostio(name string, args, outs []byte, ink uint64)       {}
-func (*StructLogger) CaptureStylusHostio(name string, args, outs []byte, ink uint64)     {}
-func (*mdLogger) CaptureStylusHostio(name string, args, outs []byte, ink uint64)         {}
+func (*AccessListTracer) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64) {
+}
+func (*JSONLogger) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64)   {}
+func (*StructLogger) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64) {}
+func (*mdLogger) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64)     {}

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -131,9 +131,9 @@ func (t *muxTracer) CaptureArbitrumTransfer(env *vm.EVM, from, to *common.Addres
 	}
 }
 
-func (t *muxTracer) CaptureStylusHostio(name string, args, outs []byte, ink uint64) {
+func (t *muxTracer) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64) {
 	for _, t := range t.tracers {
-		t.CaptureStylusHostio(name, args, outs, ink)
+		t.CaptureStylusHostio(name, args, outs, startInk, endInk)
 	}
 }
 

--- a/eth/tracers/native/tracer_arbitrum.go
+++ b/eth/tracers/native/tracer_arbitrum.go
@@ -90,11 +90,11 @@ func (*noopTracer) CaptureArbitrumStorageSet(key, value common.Hash, depth int, 
 func (*prestateTracer) CaptureArbitrumStorageSet(key, value common.Hash, depth int, before bool) {}
 func (*flatCallTracer) CaptureArbitrumStorageSet(key, value common.Hash, depth int, before bool) {}
 
-func (*callTracer) CaptureStylusHostio(name string, args, outs []byte, ink uint64)     {}
-func (*fourByteTracer) CaptureStylusHostio(name string, args, outs []byte, ink uint64) {}
-func (*noopTracer) CaptureStylusHostio(name string, args, outs []byte, ink uint64)     {}
-func (*prestateTracer) CaptureStylusHostio(name string, args, outs []byte, ink uint64) {}
-func (*flatCallTracer) CaptureStylusHostio(name string, args, outs []byte, ink uint64) {}
+func (*callTracer) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64)     {}
+func (*fourByteTracer) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64) {}
+func (*noopTracer) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64)     {}
+func (*prestateTracer) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64) {}
+func (*flatCallTracer) CaptureStylusHostio(name string, args, outs []byte, startInk, endInk uint64) {}
 
 func bigToHex(n *big.Int) string {
 	if n == nil {


### PR DESCRIPTION
Exposes both the `startInk` and `endInk` for hostios when tracing