### PR TITLE
Separate Nitro and Stylus `ChainRules` and Precompiles Lists

### DIFF
--- a/core/types/arbitrum_signer.go
+++ b/core/types/arbitrum_signer.go
@@ -6,9 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const ArbosVersion_FixRedeemGas = uint64(11)
-const ArbosVersion_Stylus = uint64(30)
-
 var ArbosAddress = common.HexToAddress("0xa4b05")
 var ArbosStateAddress = common.HexToAddress("0xA4B05FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
 var ArbSysAddress = common.HexToAddress("0x64")

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -150,8 +150,10 @@ func init() {
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
+	case rules.IsStylus:
+		return PrecompiledAddressesArbitrumStylus
 	case rules.IsArbitrum:
-		return PrecompiledAddressesArbitrum
+		return PrecompiledAddressesArbitrumNitro
 	case rules.IsCancun:
 		return PrecompiledAddressesCancun
 	case rules.IsBerlin:

--- a/core/vm/contracts_arbitrum.go
+++ b/core/vm/contracts_arbitrum.go
@@ -3,6 +3,8 @@ package vm
 import "github.com/ethereum/go-ethereum/common"
 
 var (
-	PrecompiledContractsArbitrum = make(map[common.Address]PrecompiledContract)
-	PrecompiledAddressesArbitrum []common.Address
+	PrecompiledContractsArbitrumNitro  = make(map[common.Address]PrecompiledContract)
+	PrecompiledContractsArbitrumStylus = make(map[common.Address]PrecompiledContract)
+	PrecompiledAddressesArbitrumNitro  []common.Address
+	PrecompiledAddressesArbitrumStylus []common.Address
 )

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -42,8 +42,10 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
+	case evm.chainRules.IsStylus:
+		precompiles = PrecompiledContractsArbitrumStylus
 	case evm.chainRules.IsArbitrum:
-		precompiles = PrecompiledContractsArbitrum
+		precompiles = PrecompiledContractsArbitrumNitro
 	case evm.chainRules.IsCancun:
 		precompiles = PrecompiledContractsCancun
 	case evm.chainRules.IsBerlin:
@@ -523,7 +525,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		err = ErrInvalidCode
 
 		// Arbitrum: retain Stylus programs and instead store them in the DB alongside normal EVM bytecode.
-		if evm.IsStylus() && state.IsStylusProgram(ret) {
+		if evm.chainRules.IsStylus && state.IsStylusProgram(ret) {
 			err = nil
 		}
 	}

--- a/core/vm/evm_arbitrum.go
+++ b/core/vm/evm_arbitrum.go
@@ -37,10 +37,6 @@ func (evm *EVM) DecrementDepth() {
 	evm.depth -= 1
 }
 
-func (evm *EVM) IsStylus() bool {
-	return evm.chainRules.IsArbitrum && evm.Context.ArbOSVersion >= types.ArbosVersion_Stylus
-}
-
 type TxProcessingHook interface {
 	StartTxHook() (bool, uint64, error, []byte) // return 4-tuple rather than *struct to avoid an import cycle
 	GasChargingHook(gasRemaining *uint64) (common.Address, error)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -170,7 +170,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	}
 
 	// Arbitrum: handle Stylus programs
-	if in.evm.IsStylus() && state.IsStylusProgram(contract.Code) {
+	if in.evm.chainRules.IsStylus && state.IsStylusProgram(contract.Code) {
 		ret, err = in.evm.ProcessingHook.ExecuteWASM(callContext, input, in)
 		return
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -866,7 +866,7 @@ func (err *ConfigCompatError) Error() string {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	IsArbitrum                                              bool
+	IsArbitrum, IsStylus                                    bool
 	ChainID                                                 *big.Int
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
@@ -883,6 +883,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64, curren
 	}
 	return Rules{
 		IsArbitrum:       c.IsArbitrum(),
+		IsStylus:         c.IsArbitrum() && currentArbosVersion >= ArbosVersion_Stylus,
 		ChainID:          new(big.Int).Set(chainID),
 		IsHomestead:      c.IsHomestead(num),
 		IsEIP150:         c.IsEIP150(num),

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -22,6 +22,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+const ArbosVersion_FixRedeemGas = uint64(11)
+const ArbosVersion_Stylus = uint64(30)
+
 type ArbitrumChainParams struct {
 	EnableArbOS               bool
 	AllowDebugPrecompiles     bool


### PR DESCRIPTION
Separates out our chain rules and precompile lists to avoid the wrong addresses being hot